### PR TITLE
Install specific version of docstr-coverage

### DIFF
--- a/.github/workflows/docstr-cov.yml
+++ b/.github/workflows/docstr-cov.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: 3.x
 
       - name: Install docstr-coverage
-        run: pip install docstr-coverage
+        run: pip install docstr-coverage==2.2.0
 
       - name: Get SHAs
         run: |


### PR DESCRIPTION
Just found this action! Was thinking about setting up smth like this for a while. Nicely done!

Scrolling over the code I noticed you're installing the latest version of `docstr-coverage`. While we try our best to be backwards-compatible, it's probably best to fix a specific version and update that periodically. What do you think?